### PR TITLE
Add context menu to content list

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@automerge/automerge": "^2.0.1-alpha.1",
+    "@popperjs/core": "^2.11.6",
     "@types/lodash.memoize": "^4.1.7",
     "automerge-repo": "0.0.36",
     "automerge-repo-network-messagechannel": "0.0.31",
@@ -33,6 +34,7 @@
     "react-dom": "^18.2.0",
     "react-dropdown-select": "^4.9.0",
     "react-pdf": "^5.7.2",
+    "react-popper": "^2.3.0",
     "react-tag-autocomplete": "^6.3.0",
     "uuid": "^9.0.0"
   },

--- a/src/components/NewDocumentButton.tsx
+++ b/src/components/NewDocumentButton.tsx
@@ -41,7 +41,7 @@ export default function NewDocumentButton({
   }
 
   return (
-    <Popover closeOnClick={true} trigger={trigger}>
+    <Popover closeOnClick={true} trigger={trigger} placement={"bottom-start"}>
       <ListMenuSection>
         {contentTypes.map((contentType) => (
           <ListMenuItem

--- a/src/components/TitleEditor.tsx
+++ b/src/components/TitleEditor.tsx
@@ -1,7 +1,13 @@
 import { DocumentId } from "automerge-repo"
 import { useDocument } from "automerge-repo-react-hooks"
 
-import React, { useRef } from "react"
+import React, {
+  MutableRefObject,
+  Ref,
+  RefCallback,
+  useCallback,
+  useRef,
+} from "react"
 
 import "./TitleEditor.css"
 
@@ -14,14 +20,21 @@ interface Props {
   field?: string
   placeholder?: string
   preventDrag?: boolean
+  onBlur?: () => void
+  autoselect?: boolean
 }
 
 // `preventDrag` is a little kludgey, but is required to enable text selection if the
 // input is in a draggable element.
 export default function TitleEditor(props: Props) {
   const [doc, changeDoc] = useDocument<AnyDoc>(props.documentId)
-  const input = useRef<HTMLInputElement>(null)
-  const { field = "title", preventDrag = false, placeholder = "" } = props
+  const input: MutableRefObject<HTMLInputElement | null> = useRef(null)
+  const {
+    field = "title",
+    preventDrag = false,
+    placeholder = "",
+    onBlur,
+  } = props
 
   function onKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" || e.key === "Escape") {
@@ -43,6 +56,17 @@ export default function TitleEditor(props: Props) {
     }
   }
 
+  const onRef = useCallback(
+    (element: HTMLInputElement) => {
+      if (props.autoselect && element) {
+        element.select()
+      }
+
+      input.current = element
+    },
+    [input]
+  )
+
   if (!doc) {
     return null
   }
@@ -52,7 +76,7 @@ export default function TitleEditor(props: Props) {
   return (
     <>
       <input
-        ref={input}
+        ref={onRef}
         draggable={preventDrag}
         onDragStart={onDragStart}
         type="text"
@@ -61,6 +85,7 @@ export default function TitleEditor(props: Props) {
         placeholder={placeholder}
         onKeyDown={onKeyDown}
         onChange={onChange}
+        onBlur={onBlur}
       />
       <span className="TitleEditor">{doc[field]}</span>
     </>

--- a/src/components/content-types/ContentList.css
+++ b/src/components/content-types/ContentList.css
@@ -28,3 +28,11 @@
 .ContentList--newItem-icon {
   padding: 0 6px;
 }
+
+.ContentListItem .PdfContent-button {
+  display: none;
+}
+
+.ContentListItem:hover .PdfContent-button {
+  display: inherit;
+}

--- a/src/components/content-types/ContentList.tsx
+++ b/src/components/content-types/ContentList.tsx
@@ -213,6 +213,7 @@ export default function ContentList({ documentId }: ContentProps) {
                   }
                   placement="right-start"
                   closeOnClick={true}
+                  skidding={-4}
                 >
                   <ListMenuSection>
                     <ListMenuItem

--- a/src/components/content-types/TextContent.tsx
+++ b/src/components/content-types/TextContent.tsx
@@ -33,6 +33,7 @@ import {
 import { createDocumentLink } from "../pushpin-code/Url"
 import memoize from "lodash.memoize"
 import { Doc, getHeads } from "@automerge/automerge"
+import { ContentListItemProps } from "./ContentList"
 
 Quill.register("modules/cursors", QuillCursors)
 
@@ -291,8 +292,8 @@ function create({ text }: any, handle: DocHandle<any>) {
   })
 }
 
-function TextInList(props: EditableContentProps) {
-  const { documentId, url, editable } = props
+function TextInList(props: ContentListItemProps) {
+  const { documentId, url, editable, onBlur } = props
   const [doc] = useDocument<TextDoc>(documentId)
   const lastSeenHeads = useLastSeenHeads(createDocumentLink("text", documentId))
 
@@ -328,6 +329,7 @@ function TextInList(props: EditableContentProps) {
         title={title}
         documentId={documentId}
         editable={editable}
+        onBlur={onBlur}
       />
     </ListItem>
   )

--- a/src/components/content-types/ThreadContent.tsx
+++ b/src/components/content-types/ThreadContent.tsx
@@ -23,6 +23,7 @@ import {
 } from "../pushpin-code/Changes"
 import { Doc, getHeads } from "@automerge/automerge"
 import memoize from "lodash.memoize"
+import { ContentListItemProps } from "./ContentList"
 
 interface Message {
   authorId: DocumentId
@@ -135,8 +136,8 @@ function preventDefault(e: React.SyntheticEvent) {
   e.preventDefault()
 }
 
-export function ThreadInList(props: EditableContentProps) {
-  const { documentId, url, editable } = props
+export function ThreadInList(props: ContentListItemProps) {
+  const { documentId, url, editable, onBlur } = props
   const [doc] = useDocument<ThreadDoc>(documentId)
   const lastSeenHeads = useLastSeenHeads(
     createDocumentLink("thread", documentId)
@@ -174,6 +175,7 @@ export function ThreadInList(props: EditableContentProps) {
         title={title}
         documentId={documentId}
         editable={editable}
+        onBlur={onBlur}
       />
     </ListItem>
   )

--- a/src/components/content-types/TodoList.tsx
+++ b/src/components/content-types/TodoList.tsx
@@ -20,6 +20,7 @@ import "./TodoList.css"
 import ActionListItem from "./workspace/omnibox/ActionListItem"
 import Actions from "./workspace/omnibox/Actions"
 import Action from "./workspace/omnibox/Action"
+import { ContentListItemProps } from "./ContentList"
 
 interface Source {
   url: PushpinUrl
@@ -163,8 +164,8 @@ function preventDefault(e: React.SyntheticEvent) {
   e.preventDefault()
 }
 
-export function TodoListInList(props: EditableContentProps) {
-  const { documentId, url, editable } = props
+export function TodoListInList(props: ContentListItemProps) {
+  const { documentId, url, editable, onBlur } = props
   const [doc] = useDocument<TodoListDoc>(documentId)
   if (!doc || !doc.todos) return null
 
@@ -181,6 +182,7 @@ export function TodoListInList(props: EditableContentProps) {
         title={title}
         documentId={documentId}
         editable={editable}
+        onBlur={onBlur}
       />
     </ListItem>
   )

--- a/src/components/content-types/board/BoardInList.tsx
+++ b/src/components/content-types/board/BoardInList.tsx
@@ -6,9 +6,10 @@ import Badge, { Props as BadgeProps } from "../../ui/Badge"
 import ListItem from "../../ui/ListItem"
 import TitleWithSubtitle from "../../ui/TitleWithSubtitle"
 import ContentDragHandle from "../../ui/ContentDragHandle"
+import { ContentListItemProps } from "../ContentList"
 
-export default function BoardInList(props: EditableContentProps) {
-  const { documentId, url, editable } = props
+export default function BoardInList(props: ContentListItemProps) {
+  const { documentId, url, editable, onBlur } = props
   const [doc] = useDocument<BoardDoc>(documentId)
 
   if (!doc || !doc.cards) {
@@ -36,6 +37,7 @@ export default function BoardInList(props: EditableContentProps) {
         subtitle={subtitle}
         documentId={documentId}
         editable={editable}
+        onBlur={onBlur}
       />
     </ListItem>
   )

--- a/src/components/content-types/files/FileContent.tsx
+++ b/src/components/content-types/files/FileContent.tsx
@@ -37,12 +37,8 @@ VVV permanent and unchanging (and required to render) VVV
 fileId: { "mimetype": "binary/pdf", length: 8000, "extension": "PDF"}
 */
 
-export default function FileContent({
-  documentId,
-  context,
-  editable,
-  url,
-}: Props) {
+export default function FileContent(props: Props) {
+  const { documentId, context, editable, url } = props
   const [doc] = useDocument<FileDoc>(documentId)
   const badgeRef = useRef<HTMLDivElement>(null)
 
@@ -76,6 +72,7 @@ export default function FileContent({
               subtitle={subtitle}
               documentId={documentId}
               editable={editable}
+              onBlur={"onBlur" in props ? (props as any).onBlur : undefined} // todo: this is not great
             />
           </ListItem>
         )

--- a/src/components/content-types/files/ImageContent.tsx
+++ b/src/components/content-types/files/ImageContent.tsx
@@ -15,6 +15,7 @@ import {
   createBinaryDataUrl,
   useBinaryDataHeader,
 } from "../../../blobstore/Blob"
+import { ContentListItemProps } from "../ContentList"
 
 function humanFileSize(size: number) {
   const i = size ? Math.floor(Math.log(size) / Math.log(1024)) : 0
@@ -36,12 +37,8 @@ export default function ImageContent({ documentId }: ContentProps) {
   )
 }
 
-interface Props extends ContentProps {
-  editable: boolean
-}
-
-function ImageInList(props: Props) {
-  const { documentId, editable, url } = props
+function ImageInList(props: ContentListItemProps) {
+  const { documentId, editable, url, onBlur } = props
   const [doc] = useDocument<FileDoc>(documentId)
 
   const { title = "", binaryDataId, extension } = doc || {}
@@ -74,6 +71,7 @@ function ImageInList(props: Props) {
         subtitle={subtitle}
         documentId={documentId}
         editable={editable}
+        onBlur={onBlur}
       />
     </ListItem>
   )

--- a/src/components/content-types/files/PdfContent.css
+++ b/src/components/content-types/files/PdfContent.css
@@ -61,7 +61,6 @@
   justify-content: center;
   padding: 8px;
   top: 40px;
-  z-index: 10;
   background-color: white;
   border-bottom: 1px solid var(--colorPaleGrey);
 }

--- a/src/components/content-types/files/PdfContent.tsx
+++ b/src/components/content-types/files/PdfContent.tsx
@@ -364,7 +364,7 @@ export default function PdfContent(props: ContentProps) {
                 <i className="fa fa-ellipsis-h" />
               </button>
             }
-            alignment="right"
+            placement="right"
           >
             <div className="PdfContent-popover">
               <label className="Popover-entry">

--- a/src/components/content-types/files/PdfContent.tsx
+++ b/src/components/content-types/files/PdfContent.tsx
@@ -364,7 +364,7 @@ export default function PdfContent(props: ContentProps) {
                 <i className="fa fa-ellipsis-h" />
               </button>
             }
-            placement="right"
+            placement="bottom"
           >
             <div className="PdfContent-popover">
               <label className="Popover-entry">

--- a/src/components/ui/Popover.css
+++ b/src/components/ui/Popover.css
@@ -2,21 +2,7 @@
   position: relative;
 }
 
-.Popover > .ContextMenu {
-  position: absolute;
-  top: 100%;
-  display: none;
-}
-
-.Popover.right > .ContextMenu {
-  right: 0;
-}
-
-.Popover.left > .ContextMenu {
-  left: 0;
-}
-
-.Popover.is-open > .ContextMenu {
+.ContextMenu {
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/components/ui/Popover.tsx
+++ b/src/components/ui/Popover.tsx
@@ -14,6 +14,8 @@ interface PopOverMenuProps extends React.PropsWithChildren {
   trigger: React.ReactElement
   closeOnClick?: boolean
   placement?: Placement
+  distance?: number // add a gap between the trigger and the popover
+  skidding?: number // shift the popover relative to the trigger
 }
 
 export function Popover({
@@ -21,18 +23,24 @@ export function Popover({
   closeOnClick = false,
   children,
   placement = "auto",
+  distance = 5,
+  skidding = 0,
 }: PopOverMenuProps) {
   const [referenceElement, setReferenceElement] =
     useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
     null
   )
-  const [arrowElement, setArrowElement] = useState<HTMLDivElement | null>(null)
   const { styles } = usePopper(referenceElement, popperElement, {
     placement,
     strategy: "fixed",
     modifiers: [
-      { name: "arrow", options: { element: arrowElement } },
+      {
+        name: "offset",
+        options: {
+          offset: [skidding, distance],
+        },
+      },
       {
         name: "preventOverflow",
         options: { boundary: document.body },
@@ -99,7 +107,6 @@ export function Popover({
           onClick={onClickInside}
           style={styles.popper}
         >
-          <div ref={setArrowElement} style={styles.arrow} />
           {children}
         </div>
       )}

--- a/src/components/ui/TitleWithSubtitle.tsx
+++ b/src/components/ui/TitleWithSubtitle.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useCallback, useState } from "react"
 import "./Heading.css"
 import Heading from "./Heading"
 import SecondaryText from "./SecondaryText"
@@ -14,6 +14,7 @@ export interface Props {
   editable?: boolean
   href?: string // this is because URL Content wants to have a link as its secondary text :/
   documentId: DocumentId
+  onBlur?: () => void
 }
 
 export default function TitleWithSubtitle(props: Props) {
@@ -25,7 +26,10 @@ export default function TitleWithSubtitle(props: Props) {
     subtitle,
     href,
     documentId,
+    onBlur,
   } = props
+
+  const [initialEditable] = useState(editable)
 
   return (
     <div className="TitleWithSubtitle">
@@ -34,6 +38,8 @@ export default function TitleWithSubtitle(props: Props) {
           field={titleEditorField}
           placeholder={title}
           documentId={documentId}
+          onBlur={onBlur}
+          autoselect={!initialEditable}
         />
       ) : (
         <Heading wrap={wrapTitle}>{title}</Heading>

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@popperjs/core@^2.11.6":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
+  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
 "@swc/core-darwin-arm64@1.3.14":
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.14.tgz#47350e5cc3807a44321e883b35516146747ce4d0"
@@ -1391,7 +1396,7 @@ lodash@^4.0.1, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1680,6 +1685,11 @@ react-dropdown-select@^4.9.0:
     "@emotion/react" "11.8.1"
     "@emotion/styled" "11.8.1"
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -1700,6 +1710,14 @@ react-pdf@^5.7.2:
     prop-types "^15.6.2"
     tiny-invariant "^1.0.0"
     tiny-warning "^1.0.0"
+
+react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-refresh@^0.14.0:
   version "0.14.0"
@@ -1922,6 +1940,13 @@ vite@^3, vite@^3.1.0:
     rollup "^2.79.1"
   optionalDependencies:
     fsevents "~2.3.2"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 web-streams-polyfill@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
I've added a context menu Instead of having actions directly in the content list. Also, the title is now not editable by default. This also introduces a better implementation for popovers using popper.js.

This change was motivated by getting rid of the gray text state so we can use that for differentiating read vs unread documents.

The way the edit mode switching is implemented is very hacky. But I think there could be a more principled way that actions could be implemented. The problem is that we want to collect the actions on a parent component, but the logic edit switching logic has to be implemented in the child component. I think context menus as a way to collect actions that are defined below is a useful mechanism. This is related to the haystack paper where you could right-click on any component in the hierarchy and get a list of actions that apply to it. The problem there was that if you right-clicked on an element it was unclear if you meant to interact with the element or its parent, so they showed all possible actions on the element itself and all its parents. We could avoid this problem if actions get collected in context menus that can be defined at different levels of the hierarchy.

