### PR TITLE
adds support for chrome on android

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@automerge/automerge": "^2.0.1-alpha.1",
+    "@okikio/sharedworker": "^1.0.4",
     "@types/lodash.memoize": "^4.1.7",
     "automerge-repo": "0.0.40",
     "automerge-repo-network-messagechannel": "^0.0.40",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
+import { SharedWorkerPolyfill as SharedWorker } from "@okikio/sharedworker"
 import Root from "./components/Root"
 import "./App.css"
 import "./ibm-plex.css"

--- a/src/shared-worker.ts
+++ b/src/shared-worker.ts
@@ -50,6 +50,10 @@ const repo = new Repo({
 self.addEventListener("connect", (e: MessageEvent) => {
   console.log("client connected to shared-worker")
   var mainPort = e.ports[0]
+  start(mainPort)
+})
+
+const start = (mainPort: MessagePort) => {
   mainPort.postMessage("READY")
   mainPort.onmessage = function (e: MessageEvent<SharedWorkerMessage>) {
     const data = e.data
@@ -61,7 +65,7 @@ self.addEventListener("connect", (e: MessageEvent) => {
       configureRepoNetworkPort(data.repoNetworkPort)
     }
   }
-})
+}
 
 function configureServiceWorkerPort(port: MessagePort) {
   port.onmessage = (e) => {
@@ -105,5 +109,10 @@ async function configureRepoNetworkPort(port: MessagePort) {
   )
 }, 100)
 */
+
+
+// This is the fallback for WebWorkers, in case the browser doesn't support SharedWorkers natively
+if (!("SharedWorkerGlobalScope" in self)) 
+    start(self as unknown as MessagePort)
 
 console.log("ran shared-worker to end")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   },
 
   server: {
+    host: '0.0.0.0',
     fs: {
       strict: false,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@okikio/sharedworker@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@okikio/sharedworker/-/sharedworker-1.0.4.tgz#13487fcb7d951fdfa96887335c77391b48b98ea9"
+  integrity sha512-QffYDNQ30RtrvmTVDu5WtNiwZRcrx+3Lkd02STsMXj3JBJMWmJkiQv+ruKgsLoijXVwqjW6LYuf41of7Ro/rfg==
+
 "@swc/core-darwin-arm64@1.3.14":
   version "1.3.14"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.14.tgz#47350e5cc3807a44321e883b35516146747ce4d0"


### PR DESCRIPTION
Thanks for this great project!

Chrome on Android [does not support SharedWorkers yet](https://caniuse.com/sharedworkers) but there is [a polyfill](https://github.com/okikio/sharedworker) that falls back to using a WebWorker.

The downside is that cross-tab communication still only works on desctops but the change does allow users to run blutack on their phone/tablet (which makes it much easier to show to folks!)